### PR TITLE
V3.8

### DIFF
--- a/assets/thorigins/lang/zh_cn.json
+++ b/assets/thorigins/lang/zh_cn.json
@@ -53,7 +53,6 @@
 	"origin.thorigin.sleepin1": "主动能力，站立不动，蹲下并按 [",
 	"origin.thorigin.sleepin2": "] 使用",
 
-	"origin.thorigin.cant_sleep_light": "这里太亮了睡不着！",
 	"origin.thorigin.cant_sleep_shade": "你的狐狸基因阻止你露天睡觉！",
 	"origin.thorigin.cant_sleep_fear": "你现在不能睡觉，周围有令你恐惧的东西!",
 	"origin.thorigin.cant_sleep_hunt": "你正在狩猎!别偷懒!",

--- a/data/thorigins/powers/fox/loadin.json
+++ b/data/thorigins/powers/fox/loadin.json
@@ -33,6 +33,10 @@
 				{
 					"type": "origins:execute_command",
 					"command": "/scoreboard players set @s[scores={foxtype=4}] foxtype 0"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "/tag @s add foxie"
 				}
 			]
 		}
@@ -297,6 +301,15 @@
 					}
 				}
 			]
+		}
+	},
+
+	"periodic_check": {
+		"type": "origins:action_over_time",
+		"interval": 12000,
+		"entity_action": {
+			"type": "origins:execute_command",
+			"command": "/execute as @a[tag=foxie] run tag @s remove foxie"
 		}
 	}
 }

--- a/data/thorigins/powers/fox/thdash.json
+++ b/data/thorigins/powers/fox/thdash.json
@@ -679,18 +679,18 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.5,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}
@@ -1100,18 +1100,18 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.0625,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}
@@ -1146,18 +1146,18 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.0375,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}
@@ -1432,18 +1432,18 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.33,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}

--- a/data/thorigins/powers/fox/thfluffy.json
+++ b/data/thorigins/powers/fox/thfluffy.json
@@ -15,7 +15,7 @@
 		},
 		"modifier": {
 			"name": "Origin modifier",
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.5
 		}
 	},
@@ -37,7 +37,7 @@
 		"attribute": "minecraft:generic.movement_speed",
 		"modifier": {
 			"name": "Origin modifier",
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": -0.2
 		},
 		"condition": {
@@ -63,7 +63,7 @@
 
 	"wetness": {
 		"type": "origins:resource",
-		"max": 100,
+		"max": 200,
 		"min": 0,
 		"start_value": 0,
 		"hud_render": {
@@ -73,7 +73,7 @@
 
 	"snowness": {
 		"type": "origins:resource",
-		"max": 100,
+		"max": 200,
 		"min": 0,
 		"start_value": 0,
 		"hud_render": {
@@ -327,6 +327,60 @@
 				{
 					"type": "origins:if_else",
 					"condition": {
+						"type": "origins:and",
+						"conditions": [
+							{
+								"type": "origins:resource",
+								"resource": "*:*_wetness",
+								"compare_to": 20,
+								"comparison": ">="
+							},
+							{
+								"type": "origins:resource",
+								"resource": "*:*_snowness",
+								"compare_to": 20,
+								"comparison": ">="
+							},
+							{
+								"type": "origins:or",
+								"conditions": [
+									{
+										"type": "origins:resource",
+										"resource": "*:*_avoid_spamming_water",
+										"compare_to": 1,
+										"comparison": "=="
+									},
+									{
+										"type": "origins:resource",
+										"resource": "*:*_avoid_spamming_snow",
+										"compare_to": 1,
+										"comparison": "=="
+									}
+								]
+							}
+						]
+					},
+					"if_action": {
+						"type": "origins:and",
+						"actions": [
+							{
+								"type": "origins:change_resource",
+								"resource": "*:*_timer",
+								"change": 30,
+								"operation": "set"
+							},
+							{
+								"type": "origins:change_resource",
+								"resource": "*:*_timer2",
+								"change": 30,
+								"operation": "set"
+							}
+						]
+					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
 						"type": "origins:resource",
 						"resource": "*:*_avoid_spamming_water",
 						"compare_to": 1,
@@ -353,6 +407,36 @@
 						"change": 30,
 						"operation": "set"
 					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:resource",
+						"resource": "*:*_wetness",
+						"compare_to": 100,
+						"comparison": "<"
+					},
+					"if_action": {
+						"type": "origins:change_resource",
+						"resource": "*:*_avoid_spamming_water",
+						"change": 0,
+						"operation": "set"
+					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:resource",
+						"resource": "*:*_snowness",
+						"compare_to": 100,
+						"comparison": "<"
+					},
+					"if_action": {
+						"type": "origins:change_resource",
+						"resource": "*:*_avoid_spamming_snow",
+						"change": 0,
+						"operation": "set"
+					}
 				}
 			]
 		}
@@ -364,7 +448,7 @@
 			"should_render": false
 		},
 		"min": 0,
-		"max": 15
+		"max": 10
 	},
 
 	"avoid_spamming_snow": {
@@ -448,7 +532,7 @@
 								"type": "origins:resource",
 								"resource": "*:*_snowness",
 								"comparison": ">=",
-								"compare_to": 99
+								"compare_to": 100
 							}
 						]
 					},
@@ -467,8 +551,8 @@
 							{
 								"type": "origins:resource",
 								"resource": "*:*_wetness",
-								"comparison": ">=",
-								"compare_to": 99
+								"comparison": ">",
+								"compare_to": 100
 							},
 							{
 								"type": "origins:or",
@@ -513,7 +597,7 @@
 					"if_action": {
 						"type": "origins:change_resource",
 						"resource": "*:*_avoid_spamming_water",
-						"change": 15,
+						"change": 10,
 						"operation": "set"
 					}
 				},
@@ -804,16 +888,6 @@
 		}
 	},
 
-	"natural_evaporation_cooldown": {
-		"type": "origins:resource",
-		"min": 0,
-		"max": 1200,
-		"start_value": 0,
-		"hud_render": {
-			"should_render": false
-		}
-	},
-
 	"evaporation": {
 		"type": "origins:action_over_time",
 		"interval": 20,
@@ -823,94 +897,91 @@
 				{
 					"type": "origins:if_else",
 					"condition": {
-						"type": "origins:or",
-						"conditions": [
-							{
-								"type": "origins:fluid_height",
-								"fluid": "minecraft:water",
-								"compare_to": 0.25,
-								"comparison": ">="
-							},
-							{
-								"type": "origins:in_rain"
-							},
-							{
-								"type": "origins:swimming"
-							},
-							{
-								"type": "origins:and",
-								"conditions": [
-									{
-										"type": "origins:in_block",
-										"block_condition": {
-											"type": "origins:block_state",
-											"property": "level",
-											"compare_to": 1,
-											"comparison": ">"
-										}
-									},
-									{
-										"type": "origins:in_block",
-										"block_condition": {
-											"type": "origins:block",
-											"block": "water_cauldron"
-										}
-									}
-								]
-							},
-							{
-								"type": "origins:in_block",
-								"block_condition": {
-									"type": "origins:block",
-									"block": "powder_snow"
-								}
-							},
-							{
-								"type": "origins:and",
-								"conditions": [
-									{
-										"type": "origins:in_block",
-										"block_condition": {
-											"type": "origins:block_state",
-											"property": "level",
-											"compare_to": 1,
-											"comparison": ">"
-										}
-									},
-									{
-										"type": "origins:in_block",
-										"block_condition": {
-											"type": "origins:block",
-											"block": "powder_snow_cauldron"
-										}
-									}
-								]
-							}
-						]
-					},
-					"if_action": {
-						"type": "origins:change_resource",
-						"resource": "*:*_natural_evaporation_cooldown",
-						"change": 1200,
-						"operation": "set"
-					}
-				},
-				{
-					"type": "origins:if_else",
-					"condition": {
 						"type": "origins:and",
 						"conditions": [
 							{
-								"type": "origins:resource",
-								"resource": "*:*_natural_evaporation_cooldown",
-								"comparison": ">",
-								"compare_to": 0
+								"type": "origins:or",
+								"conditions": [
+									{
+										"type": "origins:resource",
+										"resource": "*:*_wetness",
+										"comparison": ">",
+										"compare_to": 0
+									},
+									{
+										"type": "origins:resource",
+										"resource": "*:*_snowness",
+										"comparison": ">",
+										"compare_to": 0
+									}
+								]
 							},
 							{
-								"type": "origins:resource",
-								"resource": "*:*_natural_evaporation_cooldown",
-								"comparison": "<=",
-								"compare_to": 1198
+								"type": "origins:or",
+								"inverted": true,
+								"conditions": [
+									{
+										"type": "origins:fluid_height",
+										"fluid": "minecraft:water",
+										"compare_to": 0.25,
+										"comparison": ">="
+									},
+									{
+										"type": "origins:in_rain"
+									},
+									{
+										"type": "origins:swimming"
+									},
+									{
+										"type": "origins:and",
+										"conditions": [
+											{
+												"type": "origins:in_block",
+												"block_condition": {
+													"type": "origins:block_state",
+													"property": "level",
+													"compare_to": 1,
+													"comparison": ">"
+												}
+											},
+											{
+												"type": "origins:in_block",
+												"block_condition": {
+													"type": "origins:block",
+													"block": "water_cauldron"
+												}
+											}
+										]
+									},
+									{
+										"type": "origins:in_block",
+										"block_condition": {
+											"type": "origins:block",
+											"block": "powder_snow"
+										}
+									},
+									{
+										"type": "origins:and",
+										"conditions": [
+											{
+												"type": "origins:in_block",
+												"block_condition": {
+													"type": "origins:block_state",
+													"property": "level",
+													"compare_to": 1,
+													"comparison": ">"
+												}
+											},
+											{
+												"type": "origins:in_block",
+												"block_condition": {
+													"type": "origins:block",
+													"block": "powder_snow_cauldron"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
@@ -936,16 +1007,21 @@
 						"type": "origins:and",
 						"conditions": [
 							{
-								"type": "origins:resource",
-								"resource": "*:*_natural_evaporation_cooldown",
-								"comparison": ">",
-								"compare_to": 0
-							},
-							{
-								"type": "origins:resource",
-								"resource": "*:*_natural_evaporation_cooldown",
-								"comparison": "<=",
-								"compare_to": 1198
+								"type": "origins:or",
+								"conditions": [
+									{
+										"type": "origins:resource",
+										"resource": "*:*_wetness",
+										"comparison": ">",
+										"compare_to": 0
+									},
+									{
+										"type": "origins:resource",
+										"resource": "*:*_snowness",
+										"comparison": ">",
+										"compare_to": 0
+									}
+								]
 							},
 							{
 								"type": "origins:or",
@@ -969,6 +1045,9 @@
 									},
 									{
 										"type": "origins:exposed_to_sun"
+									},
+									{
+										"type": "origins:moving"
 									}
 								]
 							}
@@ -988,6 +1067,129 @@
 								"change": -4
 							}
 						]
+					}
+				}
+			]
+		}
+	},
+
+	"moving_restriction": {
+		"type": "origins:action_over_time",
+		"interval": 1,
+		"entity_action": {
+			"type": "origins:and",
+			"actions": [
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:and",
+						"conditions": [
+							{
+								"type": "origins:resource",
+								"resource": "*:*_avoid_spamming_water",
+								"compare_to": 2,
+								"comparison": ">"
+							},
+							{
+								"type": "origins:moving"
+							},
+							{
+								"type": "origins:resource",
+								"resource": "*:*_wetness",
+								"compare_to": 100,
+								"comparison": ">="
+							}
+						]
+					},
+					"if_action": {
+						"type": "origins:change_resource",
+						"resource": "*:*_avoid_spamming_water",
+						"change": 10,
+						"operation": "set"
+					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:and",
+						"conditions": [
+							{
+								"type": "origins:resource",
+								"resource": "*:*_avoid_spamming_snow",
+								"compare_to": 2,
+								"comparison": ">"
+							},
+							{
+								"type": "origins:moving"
+							},
+							{
+								"type": "origins:resource",
+								"resource": "*:*_snowness",
+								"compare_to": 100,
+								"comparison": ">="
+							}
+						]
+					},
+					"if_action": {
+						"type": "origins:change_resource",
+						"resource": "*:*_avoid_spamming_snow",
+						"change": 10,
+						"operation": "set"
+					}
+				}
+			]
+		}
+	},
+
+	"constant_particles": {
+		"type": "origins:action_over_time",
+		"interval": 5,
+		"condition": {
+			"type": "origins:moving"
+		},
+		"entity_action": {
+			"type": "origins:and",
+			"actions": [
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:resource",
+						"resource": "*:*_wetness",
+						"compare_to": 100,
+						"comparison": ">="
+					},
+					"if_action": {
+						"type": "origins:spawn_particles",
+						"particle": "minecraft:splash",
+						"count": 3,
+						"offset_y": 0.8,
+						"spread": {
+							"x": 0.3,
+							"y": 0.2,
+							"z": 0.3
+						},
+						"speed": 0
+					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:resource",
+						"resource": "*:*_snowness",
+						"compare_to": 100,
+						"comparison": ">"
+					},
+					"if_action": {
+						"type": "origins:spawn_particles",
+						"particle": "minecraft:snowflake",
+						"count": 3,
+						"offset_y": 0.8,
+						"spread": {
+							"x": 0.3,
+							"y": 0.2,
+							"z": 0.3
+						},
+						"speed": 0
 					}
 				}
 			]

--- a/data/thorigins/powers/fox/thfood.json
+++ b/data/thorigins/powers/fox/thfood.json
@@ -18,12 +18,12 @@
         },
         "food_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 4.0
         },
         "saturation_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 16.0
         },
         "entity_action": {
@@ -214,12 +214,12 @@
         },
         "food_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 4.0
         },
         "saturation_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 16.0
         },
         "entity_action": {
@@ -474,12 +474,12 @@
         },
         "food_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 2.0
         },
         "saturation_modifier": {
             "name": "Origin modifier",
-            "operation": "addition",
+            "operation": "add_base_early",
             "value": 5.0
         },
         "prevent_effects": true,
@@ -631,12 +631,12 @@
         },
         "food_modifier": {
             "name": "Origin modifier",
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": -0.5
         },
         "saturation_modifier": {
             "name": "Origin modifier",
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": -0.5
         }
     }

--- a/data/thorigins/powers/fox/thfoxiality.json
+++ b/data/thorigins/powers/fox/thfoxiality.json
@@ -44,7 +44,7 @@
 		},
 		"modifier": {
 			"value": 3,
-			"operation": "multiply_base"
+			"operation": "multiply_base_multiplicative"
 		}
 	},
 
@@ -378,7 +378,7 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.15
 		}
 	},
@@ -405,7 +405,7 @@
 			}
 		},
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.15
 		}
 	},
@@ -417,7 +417,7 @@
 			"tag": "minecraft:mineable/shovel"
 		},
 		"modifier": {
-			"operation": "multiply_total",
+			"operation": "multiply_total_multiplicative",
 			"value": 9
 		},
 		"condition": {

--- a/data/thorigins/powers/fox/thfoxify.json
+++ b/data/thorigins/powers/fox/thfoxify.json
@@ -28,10 +28,31 @@
 				},
 				{
 					"translate": "origin.thorigin.foxhat2"
+				},
+				{
+					"text": "\n"
+				},
+				{
+					"translate": "origin.thorigin.foxrider1"
+				},
+				{
+					"keybind": "key.saveToolbarActivator"
+				},
+				{
+					"translate": "origin.thorigin.foxrider2"
 				}
 			]
 		}
 	],
+
+	"fix_bad_fox": {
+		"type": "origins:action_over_time",
+		"interval": 20,
+		"entity_action": {
+			"type": "origins:execute_command",
+			"command": "/execute as @e[type=fox,nbt={Sleeping:1b,NoAI:1b,NoGravity:1b},tag=sleepin] run execute unless entity @p[distance=..0.3] run kill @s"
+		}
+	},
 
 	"auto_decrement": {
 		"type": "origins:action_over_time",
@@ -52,6 +73,37 @@
 						"resource": "*:*_afk_timer",
 						"change": -1
 					}
+				},
+				{
+					"type": "origins:if_else",
+					"condition": {
+						"type": "origins:and",
+						"conditions": [
+							{
+								"type": "origins:resource",
+								"resource": "*:*_pressed",
+								"compare_to": 0,
+								"comparison": "=="
+							},
+							{
+								"type": "origins:resource",
+								"resource": "*:*_mounting",
+								"compare_to": 0,
+								"comparison": ">"
+							}
+						]
+					},
+					"if_action": {
+						"type": "origins:change_resource",
+						"resource": "*:*_mounting",
+						"change": 0,
+						"operation": "set"
+					}
+				},
+				{
+					"type": "origins:change_resource",
+					"resource": "*:*_pressed",
+					"change": -1
 				}
 			]
 		}
@@ -720,16 +772,20 @@
 		"type": "origins:active_self",
 		"key": "key.saveToolbarActivator",
 		"condition": {
-			"type": "origins:resource",
-			"resource": "*:*_afk_timer",
-			"compare_to": 1,
-			"comparison": "<="
+			"type": "origins:sneaking",
+			"inverted": true
 		},
 		"entity_action": {
 			"type": "origins:if_else",
 			"condition": {
 				"type": "origins:and",
 				"conditions": [
+					{
+						"type": "origins:resource",
+						"resource": "*:*_afk_timer",
+						"compare_to": 1,
+						"comparison": "<="
+					},
 					{
 						"type": "origins:resource",
 						"resource": "*:*_fox_hider",
@@ -749,6 +805,49 @@
 				"resource": "*:*_fox_hider",
 				"change": 1,
 				"operation": "set"
+			},
+			"else_action": {
+				"type": "origins:change_resource",
+				"resource": "*:*_fox_hider",
+				"change": 0,
+				"operation": "set"
+			}
+		}
+	},
+
+	"sit_mode":{
+		"type": "origins:active_self",
+		"key": "key.saveToolbarActivator",
+		"condition": {
+			"type": "origins:sneaking"
+		},
+		"entity_action": {
+			"type": "origins:if_else",
+			"condition": {
+				"type": "origins:and",
+				"conditions": [
+					{
+						"type": "origins:resource",
+						"resource": "*:*_afk_timer",
+						"compare_to": 1,
+						"comparison": "<="
+					},
+					{
+						"type": "origins:resource",
+						"resource": "*:*_ride_status",
+						"compare_to": 0,
+						"comparison": "=="
+					}
+				]
+			},
+			"if_action": {
+				"type": "origins:and",
+				"actions": [
+					{
+						"type": "origins:execute_command",
+						"command": "/data modify @e Sleeping"
+					}
+				]
 			},
 			"else_action": {
 				"type": "origins:change_resource",
@@ -1060,6 +1159,112 @@
 					}
 				}
 			]
+		}
+	},
+
+	"ride_player": {
+		"type": "origins:active_self",
+		"key": {
+			"key": "key.saveToolbarActivator",
+			"continuous": true
+		},
+		"cooldown": 1,
+		"entity_action": {
+			"type": "origins:raycast",
+			"bientity_condition": {
+				"type": "origins:target_condition",
+				"condition": {
+					"type": "origins:and",
+					"conditions": [
+						{
+							"type": "origins:entity_type",
+							"entity_type": "player"
+						},
+						{
+							"type": "origins:sneaking"
+						}
+					]
+				}
+			},
+			"distance": 3,
+			"bientity_action": {
+				"type": "origins:if_else",
+				"condition": {
+					"type": "origins:actor_condition",
+					"condition": {
+						"type": "origins:resource",
+						"resource": "*:*_mounting",
+						"compare_to": 20,
+						"comparison": "=="
+					}
+				},
+				"else_action": {
+					"type": "origins:actor_action",
+					"action": {
+						"type": "origins:and",
+						"actions": [
+							{
+								"type": "origins:change_resource",
+								"resource": "*:*_pressed",
+								"change": 2,
+								"operation": "set"
+							},
+							{
+								"type": "origins:change_resource",
+								"resource": "*:*_mounting",
+								"change": 1
+							}
+						]
+					}
+				},
+				"if_action": {
+					"type": "origins:and",
+					"actions": [
+						{
+							"type": "origins:mount"
+						},
+						{
+							"type": "origins:delay",
+							"ticks": 1,
+							"action": {
+								"type": "origins:actor_action",
+								"action": {
+									"type": "origins:change_resource",
+									"resource": "*:*_mounting",
+									"change": 0,
+									"operation": "set"
+								}
+							}
+						}
+					]
+				}
+			}
+		}
+	},
+
+	"mounting": {
+		"type": "origins:resource",
+		"min": 0,
+		"max": 20,
+		"hud_render": {
+			"should_render": true,
+			"sprite_location": "origins:textures/gui/community/huang/resource_bar_01.png",
+			"bar_index": 3,
+			"condition": {
+				"type": "origins:resource",
+				"resource": "*:*_mounting",
+				"compare_to": 1,
+				"comparison": ">"
+			}
+		}
+	},
+
+	"pressed": {
+		"type": "origins:resource",
+		"min": 0,
+		"max": 2,
+		"hud_render": {
+			"should_render": false
 		}
 	}
 }

--- a/data/thorigins/powers/fox/thhunger.json
+++ b/data/thorigins/powers/fox/thhunger.json
@@ -12,7 +12,7 @@
         "type": "origins:modify_exhaustion",
         "modifier": {
             "name": "Origin modifier",
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": 0.5
         },
         "condition": {
@@ -52,7 +52,7 @@
         },
         "modifier": {
             "value": 0.05,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -75,7 +75,7 @@
         },
         "modifier": {
             "value": -0.1,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -98,7 +98,7 @@
         },
         "modifier": {
             "value": -0.2,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -121,7 +121,7 @@
         },
         "modifier": {
             "value": -0.3,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -144,7 +144,7 @@
         },
         "modifier": {
             "value": -0.4,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -167,7 +167,7 @@
         },
         "modifier": {
             "value": -0.5,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     },
 
@@ -180,7 +180,7 @@
         },
         "modifier": {
             "value": -0.6,
-            "operation": "multiply_total"
+            "operation": "multiply_total_multiplicative"
         }
     }
 }

--- a/data/thorigins/powers/fox/thhunt.json
+++ b/data/thorigins/powers/fox/thhunt.json
@@ -72,7 +72,7 @@
 	"le_switch": {
 		"type": "origins:toggle",
 		"active_by_default": false,
-		"key": "key.origins.denary_active",
+		"key": "nuh.uh",
 		"retain_state": false
 	},
 
@@ -162,10 +162,21 @@
 						"power": "*:*_le_switch"
 					},
 					{
-						"type": "origins:resource",
-						"resource": "*:*_timer2",
-						"compare_to": 0,
-						"comparison": "=="
+						"type": "origins:or",
+						"conditions": [
+							{
+								"type": "origins:resource",
+								"resource": "*:*_timer2",
+								"compare_to": 0,
+								"comparison": "=="
+							},
+							{
+								"type": "origins:resource",
+								"resource": "*:*_timer",
+								"compare_to": 0,
+								"comparison": "!="
+							}
+						]
 					}
 				]
 			}
@@ -287,18 +298,18 @@
 	"damagebonus_day": {
 		"type": "origins:modify_damage_dealt",
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.0625,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}
@@ -379,18 +390,18 @@
 	"damagebonus_midnight": {
 		"type": "origins:modify_damage_dealt",
 		"modifier": {
-			"operation": "multiply_base",
+			"operation": "multiply_base_multiplicative",
 			"value": 0.125,
 			"modifier": {
-				"operation": "multiply_base",
+				"operation": "multiply_base_multiplicative",
 				"value": -1,
 				"modifier": {
-					"operation": "addition",
+					"operation": "add_base_early",
 					"resource": "*:fox/thtrackers_op_lvl",
 					"value": 0,
 					"modifier": {
 						"value": -0.99,
-						"operation": "multiply_base"
+						"operation": "multiply_base_multiplicative"
 					}
 				}
 			}

--- a/data/thorigins/powers/fox/thsleepin_fox.json
+++ b/data/thorigins/powers/fox/thsleepin_fox.json
@@ -45,21 +45,30 @@
 	"invulnerable": {
 		"type": "origins:invulnerability",
 		"damage_condition": {
-			"type": "origins:attacker",
-			"entity_condition": {
-				"type": "origins:or",
-				"inverted": true,
-				"conditions": [
-					{
-						"type": "origins:entity_type",
-						"entity_type": "minecraft:wolf"
-					},
-					{
-						"type": "origins:entity_type",
-						"entity_type": "minecraft:polar_bear"
+			"type": "origins:or",
+			"conditions": [
+				{
+					"type": "origins:attacker",
+					"entity_condition": {
+						"type": "origins:or",
+						"inverted": true,
+						"conditions": [
+							{
+								"type": "origins:entity_type",
+								"entity_type": "minecraft:wolf"
+							},
+							{
+								"type": "origins:entity_type",
+								"entity_type": "minecraft:polar_bear"
+							}
+						]
 					}
-				]
-			}
+				},
+				{
+					"type": "origins:name",
+					"name": "lava"
+				}
+			]
 		},
 		"condition": {
 			"type": "origins:command",

--- a/data/thorigins/powers/fox/thsmol.json
+++ b/data/thorigins/powers/fox/thsmol.json
@@ -1,67 +1,67 @@
 {
-    "type": "origins:multiple",
-    "badges": [
-        {
-            "type": "origins:keybind",
-            "sprite": "minecraft:textures/item/diamond.png",
-            "text": "origin.thorigin.passive"
-        }
-    ],
-    "adjustsize": {
-        "type": "origins:action_on_callback",
-        "entity_action_added": {
-            "type": "origins:delay",
-            "ticks": 1,
-            "action": {
-                "type": "origins:and",
-                "actions": [
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale persist set true @s"
-                    },
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale set pehkui:width 0.7 @s"
-                    },
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale set pehkui:height 0.7 @s"
-                    },
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale set pehkui:drops 0.7 @s"
-                    },
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale set pehkui:visibility 0.8 @s"
-                    },
-                    {
-                        "type": "origins:execute_command",
-                        "command": "/scale set pehkui:held_item 0.7 @s"
-                    }
-                ]
-            }
-        },
-        "entity_action_lost": {
-            "type": "origins:and",
-            "actions": [
-                {
-                    "type": "origins:execute_command",
-                    "command": "/scale reset @s"
-                }
-            ]
-        }
-    },
+	"type": "origins:multiple",
+	"badges": [
+		{
+			"type": "origins:keybind",
+			"sprite": "minecraft:textures/item/diamond.png",
+			"text": "origin.thorigin.passive"
+		}
+	],
+	"adjustsize": {
+		"type": "origins:action_on_callback",
+		"entity_action_added": {
+			"type": "origins:delay",
+			"ticks": 1,
+			"action": {
+				"type": "origins:and",
+				"actions": [
+					{
+						"type": "origins:execute_command",
+						"command": "/scale persist set true @s"
+					},
+					{
+						"type": "origins:execute_command",
+						"command": "/scale set pehkui:width 0.7 @s"
+					},
+					{
+						"type": "origins:execute_command",
+						"command": "/scale set pehkui:height 0.7 @s"
+					},
+					{
+						"type": "origins:execute_command",
+						"command": "/scale set pehkui:drops 0.7 @s"
+					},
+					{
+						"type": "origins:execute_command",
+						"command": "/scale set pehkui:visibility 0.8 @s"
+					},
+					{
+						"type": "origins:execute_command",
+						"command": "/scale set pehkui:held_item 0.7 @s"
+					}
+				]
+			}
+		},
+		"entity_action_lost": {
+			"type": "origins:and",
+			"actions": [
+				{
+					"type": "origins:execute_command",
+					"command": "/scale reset @s"
+				}
+			]
+		}
+	},
 
-    "max_health": {
-        "type": "origins:attribute",
-        "modifiers": [
-            {
-                "name": "Origin modifier",
-                "attribute": "minecraft:generic.max_health",
-                "operation": "addition",
-                "value": -4
-            }
-        ]
-    }
+	"max_health": {
+		"type": "origins:attribute",
+		"modifiers": [
+			{
+				"name": "Origin modifier",
+				"attribute": "minecraft:generic.max_health",
+				"operation": "addition",
+				"value": -4
+			}
+		]
+	}
 }

--- a/data/thorigins/powers/fox/thsound.json
+++ b/data/thorigins/powers/fox/thsound.json
@@ -534,6 +534,9 @@
 							"type": "origins:or",
 							"conditions": [
 								{
+									"type": "origins:riding"
+								},
+								{
 									"type": "origins:sneaking"
 								},
 								{
@@ -603,6 +606,10 @@
 										{
 											"type": "origins:execute_command",
 											"command": "/tag @s[tag=foxiefear] add foxietrust"
+										},
+										{
+											"type": "origins:swing_hand",
+											"hand": "MAIN_HAND"
 										}
 									]
 								}
@@ -717,6 +724,9 @@
 							"type": "origins:or",
 							"conditions": [
 								{
+									"type": "origins:riding"
+								},
+								{
 									"type": "origins:sneaking"
 								},
 								{
@@ -778,6 +788,10 @@
 								"action": {
 									"type": "origins:and",
 									"actions": [
+										{
+											"type": "origins:swing_hand",
+											"hand": "MAIN_HAND"
+										},
 										{
 											"type": "origins:execute_command",
 											"command": "/tag @s add pet"

--- a/data/thorigins/powers/fox/thswift.json
+++ b/data/thorigins/powers/fox/thswift.json
@@ -71,7 +71,7 @@
             "name": "fall"
         },
         "modifier": {
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": -0.8
         },
         "condition": {
@@ -83,7 +83,7 @@
         "type": "origins:modify_attribute",
         "attribute": "minecraft:generic.movement_speed",
         "modifier": {
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": 0.4
         },
         "condition": {
@@ -103,7 +103,7 @@
     "jumpy": {
         "type": "origins:modify_jump",
         "modifier": {
-            "operation": "multiply_base",
+            "operation": "multiply_base_multiplicative",
             "value": 0.4
         },
         "condition": {

--- a/fabric.mod.json
+++ b/fabric.mod.json
@@ -9,7 +9,7 @@
     },
     "name": "ThDilos' Custom Fox Origins",
     "id": "thorigins",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "description": "ThDilos' Custom Made Fox Origins. Slightly overpowered.",
     "license": "Unknown",
     "pack_format": 15,


### PR DESCRIPTION
V3.8 branch
If this is set up properly, you will see this message on Github
Can you? idk
Is this branch a branch in my house or a branch in the cloud? or are they quantum linked branch?
Why branch? Who is the root? where?

Changes:
1. Active Skill [Hunt]:
> Will show the preparation HUD bar during Hunting phase. This feature was unintentially removed in V3.7, now it is bacc
2. Passive Skill [Fluffy] reworked:
> 1. You can only trigger shake snow / water when you are not moving
> 2. When you run, you will give off water / snow particles, indicating that you are shakable
> 3. Evaporation will now actually do work. If you stay running while shakable, the wetness / snowness will go down and eventually you are no longer shakable
3. Active Skill [Foxify]:
> 1. Hold C against a crouching player to mount on them
> 2. Allow interaction when you are riding
> 3. [Sleepin Mode] will publically clear out error foxes
> 4. Sleepin Fox will now immune to lava
4. Hidden Skill [loadin]:
> Periodically clear out the foxie tag of all player, so that players who changed origin will no longer be foxie 